### PR TITLE
Check ahead for multitail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-multitail:
 		echo "multitail installed successfully."; \
 	fi
 
-env: uv install-multitail
+env: uv
 	@echo "Installing python dependencies..."
 	@uv add pyproject.toml
 	@echo "Installing git hooks..."
@@ -55,6 +55,12 @@ env: uv install-multitail
 		echo "Created ~/.aws/config file"; \
 	fi
 	@$(PYTHON) hacks/patch_socket.py
+	@echo "Attempting to install multitail..."
+	@if ! make install-multitail; then \
+		echo "Warning: Could not install multitail automatically."; \
+		echo "If you want to use 'make stream-logs' to stream all logs,"; \
+		echo "please install multitail manually."; \
+	fi
 
 run:
 	@echo "Starting application..."

--- a/Makefile
+++ b/Makefile
@@ -12,32 +12,36 @@ uv:
 	@echo "uv is installed"
 
 install-multitail:
-	@echo "Installing multitail..."
-	@if [ "$(shell uname)" = "Darwin" ]; then \
-		if command -v brew >/dev/null 2>&1; then \
-			brew install multitail; \
-		else \
-			echo "Homebrew is not installed. Please install Homebrew first."; \
-			exit 1; \
-		fi \
-	elif [ "$(shell uname)" = "Linux" ]; then \
-		if command -v apt-get >/dev/null 2>&1; then \
-			sudo apt-get update && sudo apt-get install -y multitail; \
-		elif command -v yum >/dev/null 2>&1; then \
-			sudo yum install -y epel-release && sudo yum install -y multitail; \
-		elif command -v dnf >/dev/null 2>&1; then \
-			sudo dnf install -y epel-release && sudo dnf install -y multitail; \
-		elif command -v pacman >/dev/null 2>&1; then \
-			sudo pacman -Sy multitail; \
-		else \
-			echo "Unsupported Linux distribution. Please install multitail manually."; \
-			exit 1; \
-		fi \
+	@if command -v multitail >/dev/null 2>&1; then \
+		echo "multitail is already installed."; \
 	else \
-		echo "Unsupported operating system. Please install multitail manually."; \
-		exit 1; \
+		echo "Installing multitail..."; \
+		if [ "$(shell uname)" = "Darwin" ]; then \
+			if command -v brew >/dev/null 2>&1; then \
+				brew install multitail; \
+			else \
+				echo "Homebrew is not installed. Please install Homebrew first."; \
+				exit 1; \
+			fi \
+		elif [ "$(shell uname)" = "Linux" ]; then \
+			if command -v apt-get >/dev/null 2>&1; then \
+				sudo apt-get update && sudo apt-get install -y multitail; \
+			elif command -v yum >/dev/null 2>&1; then \
+				sudo yum install -y epel-release && sudo yum install -y multitail; \
+			elif command -v dnf >/dev/null 2>&1; then \
+				sudo dnf install -y epel-release && sudo dnf install -y multitail; \
+			elif command -v pacman >/dev/null 2>&1; then \
+				sudo pacman -Sy multitail; \
+			else \
+				echo "Unsupported Linux distribution. Please install multitail manually."; \
+				exit 1; \
+			fi \
+		else \
+			echo "Unsupported operating system. Please install multitail manually."; \
+			exit 1; \
+		fi; \
+		echo "multitail installed successfully."; \
 	fi
-	@echo "multitail installed successfully."
 
 env: uv install-multitail
 	@echo "Installing python dependencies..."


### PR DESCRIPTION
Skip installing `multitail` if it already exists on the system. Also allowing the `env` target to continue, then prompt the user to install `multitail` on their own if they'd like to stream the logs. It's not critical for getting the application running, so let's not block on it.